### PR TITLE
Allow to select the draft from the list of recent drafts

### DIFF
--- a/src/components/RecentDrafts.vue
+++ b/src/components/RecentDrafts.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { extractDraftId } from '../utils'
+
+const props = defineProps<{
+  civPresets: string[] | null
+  mapPresets: string[] | null
+}>()
+const mapPresets = props.mapPresets ?? []
+const civPresets = props.civPresets ?? []
+
+const mapDraftURI = defineModel<string>('mapDraft')
+const civDraftURI = defineModel<string>('civDraft')
+
+const mapDraftId = computed(() => extractDraftId(mapDraftURI.value))
+const civDraftId = computed(() => extractDraftId(civDraftURI.value))
+
+type draft = {
+  draftId: string
+  presetId: string
+  title: string
+  nameHost: string
+  nameGuest: string
+}
+
+const recentDrafts = await (async () => {
+  const response = await fetch('https://aoe2cm.net/api/recentdrafts')
+  const drafts = (await response.json()) as draft[]
+  return drafts.filter(
+    (draft) => civPresets.includes(draft.presetId) || mapPresets.includes(draft.presetId)
+  )
+})()
+console.log(recentDrafts)
+
+const selectDraft = (draft: draft) => {
+  if (mapPresets.includes(draft.presetId)) {
+    if (mapDraftURI.value == draft.draftId) {
+      mapDraftURI.value = ''
+    } else {
+      mapDraftURI.value = draft.draftId
+    }
+  } else {
+    if (civDraftURI.value == draft.draftId) {
+      civDraftURI.value = ''
+    } else {
+      civDraftURI.value = draft.draftId
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="text-center p-4 border-2 col-span-3 mt-4 h-80 overflow-auto">
+    <h2 class="text-center text-2xl">Recent Drafts</h2>
+    <ul role="list" class="divide-y divide-gray-100">
+      <li class="flex justify-between" v-for="draft in recentDrafts" :key="draft.draftId">
+        <button
+          class="flex-auto text-start hover:bg-slate-100"
+          :class="{ 'bg-slate-300': [mapDraftId, civDraftId].includes(draft.draftId) }"
+          @click="selectDraft(draft)"
+        >
+          <div class="min-w-100 flex-auto">
+            <span class="text-sm font-semibold leading-6 text-gray-900">{{ draft.nameHost }}</span>
+            <span class="mt-1 truncate text-xs leading-5 text-gray-500 m-3">vs</span>
+            <span class="text-sm font-semibold leading-6 text-gray-900">{{ draft.nameGuest }}</span>
+            <span class="mt-1 truncate text-xs leading-5 text-gray-500 m-3"
+              >{{ draft.title }} ({{ draft.draftId }})</span
+            >
+          </div>
+        </button>
+      </li>
+    </ul>
+    <!-- <p v-for="draft in recentDrafts">{{ draft.title }} - {{ draft.nameHost }} vs {{ draft.nameGuest }} - -->
+    <!--   {{ draft.draftId }}</p> -->
+  </div>
+</template>

--- a/src/components/ReplayForm.vue
+++ b/src/components/ReplayForm.vue
@@ -7,6 +7,7 @@ import { saveAs } from 'file-saver'
 import GameInfo from './GameInfo.vue'
 import GameBox from './GameBox.vue'
 import PreviewPane from './PreviewPane.vue'
+import RecentDrafts from './RecentDrafts.vue'
 import type { ReplayMetadata, ReplayErrors } from '../entities/gamemeta'
 
 import { Game, Replay, zipFilename, computeReplayFilename } from '../entities/game'
@@ -18,6 +19,8 @@ const props = defineProps<{
 
 const player1 = ref('Player1')
 const player2 = ref('Player2')
+const mapDraft: Ref<string> = ref('')
+const civDraft: Ref<string> = ref('')
 const games: Ref<Game[]> = ref([new Game(), new Game(), new Game()])
 const meta: Ref<ReplayMetadata> = ref({ maps: null, civs: null })
 const metaErrors: Ref<ReplayErrors> = ref({ maps: null, civs: null })
@@ -131,10 +134,24 @@ function downloadZip() {
 </script>
 
 <template>
+  <Suspense>
+    <RecentDrafts
+      v-if="mapPresets || civPresets"
+      :civ-presets="civPresets"
+      :map-presets="mapPresets"
+      v-model:map-draft="mapDraft"
+      v-model:civ-draft="civDraft"
+    />
+    <template #fallback>
+      <div class="text-center p-4 border-2 col-span-3 mt-4 h-80">Loading Drafts...</div>
+    </template>
+  </Suspense>
   <GameInfo
     :games="games"
     v-model:player1="player1"
     v-model:player2="player2"
+    v-model:map-draft="mapDraft"
+    v-model:civ-draft="civDraft"
     :civ-presets="civPresets"
     :map-presets="mapPresets"
     @update-meta="

--- a/src/entities/aoe2cm.ts
+++ b/src/entities/aoe2cm.ts
@@ -1,22 +1,21 @@
-
 export type Aoe2CmEvent = {
-    actionType: string
-    chosenOptionId: string
-    executingPlayer: 'HOST' | 'GUEST' | 'NONE'
-    isRandomlyChosen: boolean
-    offset: number
-    player: 'HOST' | 'GUEST' | 'NONE'
+  actionType: string
+  chosenOptionId: string
+  executingPlayer: 'HOST' | 'GUEST' | 'NONE'
+  isRandomlyChosen: boolean
+  offset: number
+  player: 'HOST' | 'GUEST' | 'NONE'
 }
 
 export type Aoe2CmDraftOption = {
-    category: string
-    i18nPrefix: string
-    id: string
-    imageUrls: {
-        animated_left: string
-        animated_right: string
-        emblem: string
-        unit: string
-    }
-    name: string
+  category: string
+  i18nPrefix: string
+  id: string
+  imageUrls: {
+    animated_left: string
+    animated_right: string
+    emblem: string
+    unit: string
+  }
+  name: string
 }

--- a/src/entities/game.ts
+++ b/src/entities/game.ts
@@ -1,4 +1,4 @@
-import unidecode from 'unidecode';
+import unidecode from 'unidecode'
 
 let gameCounter = 0
 let replayCounter = 0
@@ -22,7 +22,6 @@ export class Replay {
   }
 }
 
-
 function normalizePlayerName(playerName: string, defaultName: string) {
   const asciiName = unidecode(playerName)
   const noWhitespaceName = asciiName.replace(/\s/g, '')
@@ -31,9 +30,9 @@ function normalizePlayerName(playerName: string, defaultName: string) {
   const normalizedName = noUnprintableName.replace(/[<>:"/\\|?*]/g, '')
 
   if (normalizedName.length == 0) {
-    return defaultName;
+    return defaultName
   } else {
-    return normalizedName;
+    return normalizedName
   }
 }
 
@@ -75,7 +74,13 @@ export function computeReplayFilenamePreview(
   replay: Replay,
   replayIdx: number
 ) {
-  const filename = computeReplayFilename(normalizePlayerName(player1, 'Player1'), normalizePlayerName(player2, 'Player2'), game, gameIdx, replayIdx)
+  const filename = computeReplayFilename(
+    normalizePlayerName(player1, 'Player1'),
+    normalizePlayerName(player2, 'Player2'),
+    game,
+    gameIdx,
+    replayIdx
+  )
   const dummyIndicator = replay.file ? '' : ' (dummy file)'
 
   return `${filename}${dummyIndicator}`

--- a/src/entities/gamemeta.ts
+++ b/src/entities/gamemeta.ts
@@ -1,13 +1,26 @@
-
-export type MapDraft = { draft: string; preset: string; host: string; guest: string; pickedMaps: [string], availableMaps: Record<string, { name: string; image: string }> }
-export type CivDraft = { draft: string; preset: string; host: string; guest: string; hostCivs: [string]; guestCivs: [string] }
+export type MapDraft = {
+  draft: string
+  preset: string
+  host: string
+  guest: string
+  pickedMaps: [string]
+  availableMaps: Record<string, { name: string; image: string }>
+}
+export type CivDraft = {
+  draft: string
+  preset: string
+  host: string
+  guest: string
+  hostCivs: [string]
+  guestCivs: [string]
+}
 
 export type ReplayMetadata = {
-    maps: MapDraft | null
-    civs: CivDraft | null
-};
+  maps: MapDraft | null
+  civs: CivDraft | null
+}
 
 export type ReplayErrors = {
-    maps: string | null
-    civs: string | null
+  maps: string | null
+  civs: string | null
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+export const extractDraftId = (url?: string) => {
+  if (!url) {
+    return ''
+  }
+  return url.replace(/https:\/\/aoe2cm\.net\/(draft|spectate)\//, '').replace(/\/$/, '')
+}


### PR DESCRIPTION
This change will display the latest drafts created with the provided presets. Players can simply click on the preset to select it without having to get the URL or draft ID.

![image](https://github.com/ZetaTwo/aoe2replaypacker/assets/64094/81d16625-1c1f-40b7-939d-75f1bd4511a3)
