### PR TITLE
Use presets to define number of games in the set

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -9,3 +9,7 @@
 .btn-gray {
   @apply bg-gray-200 text-black;
 }
+
+.btn-gray-disabled {
+  @apply bg-gray-200 text-gray-400 cursor-not-allowed;
+}

--- a/src/components/GameBox.vue
+++ b/src/components/GameBox.vue
@@ -30,8 +30,15 @@ defineEmits<{
           @remove-replay="$emit('removeReplay', idx)"
           @update-replay="(file) => $emit('updateReplay', idx, file)"
         />
-        <div class="p-2">
-          <button @click="$emit('addReplay')" class="btn btn-gray">Add extra replay</button>
+        <div class="p-2 grid grid-cols-[auto_2fr] gap-4">
+          <button @click="$emit('addReplay')" class="btn btn-gray">
+            Add restore for game {{ props.gameNumber + 1 }}
+          </button>
+          <div
+            class="p-2 text-sm text-blue-800 rounded-lg bg-blue-50 dark:bg-gray-800 dark:text-blue-400"
+          >
+            Add more replays if you had to restore a dropped game.
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/GameInfo.vue
+++ b/src/components/GameInfo.vue
@@ -166,7 +166,7 @@ watch(meta, () => {
 </script>
 
 <template>
-  <div class="text-center p-4 border-2 col-span-3 mt-4">
+  <div class="text-center p-4 border-2 mt-4">
     <h2 class="text-center text-2xl">Game Info</h2>
     <div>Best of {{ props.games.length }}</div>
     <input

--- a/src/components/ReplayBox.vue
+++ b/src/components/ReplayBox.vue
@@ -43,13 +43,13 @@ function clearFile() {
     <div class="p-4 col-span-1">
       <button v-if="replayFile" @click="clearFile" class="btn btn-gray">Clear file</button>
       <button
-        v-else-if="game.replays.length == 1"
+        :disabled="game.replays.length == 1"
         @click="$emit('removeReplay')"
-        class="btn btn-gray"
+        class="btn"
+        :class="game.replays.length > 1 ? 'btn-gray' : 'btn-gray-disabled'"
       >
-        Remove game
+        Remove replay
       </button>
-      <button v-else @click="$emit('removeReplay')" class="btn btn-gray">Remove replay</button>
     </div>
   </div>
 </template>

--- a/src/components/ReplayForm.vue
+++ b/src/components/ReplayForm.vue
@@ -5,6 +5,7 @@ import JSZip from 'jszip'
 import { saveAs } from 'file-saver'
 
 import GameInfo from './GameInfo.vue'
+import SetInfo from './SetInfo.vue'
 import GameBox from './GameBox.vue'
 import ZipPreviewPane from './ZipPreviewPane.vue'
 import RecentDrafts from './RecentDrafts.vue'
@@ -42,6 +43,15 @@ function updateReplay(gameIdx: number, replayIdx: number, file: File | null) {
 
 function addGame() {
   games.value.push(new Game())
+}
+
+function setGames(gamesNumber: number) {
+  while (games.value.length < gamesNumber) {
+    addGame()
+  }
+  if (games.value.length > gamesNumber) {
+    games.value = games.value.slice(0, gamesNumber)
+  }
 }
 
 const downloadEnabled = computed(() => {
@@ -161,6 +171,7 @@ function downloadZip() {
       }
     "
   />
+  <SetInfo :games-count="games.length" @set-games="setGames" />
   <GameBox
     v-for="(game, gameIdx) in games"
     :game="game"
@@ -170,9 +181,6 @@ function downloadZip() {
     @add-replay="addReplay(gameIdx)"
     @update-replay="(replayIdx, file) => updateReplay(gameIdx, replayIdx, file)"
   />
-  <div class="text-center p-4 border-2 col-span-3 mt-4">
-    <button class="btn btn-gray" @click="addGame()">Add Game</button>
-  </div>
   <div id="message_box" class="mt-4 text-center p-4 border-2 col-span-3 hidden"></div>
   <div class="text-center p-4 border-2 col-span-3 mt-4">
     <ZipPreviewPane :games="games" :player1="player1" :player2="player2" :meta="meta" />

--- a/src/components/ReplayForm.vue
+++ b/src/components/ReplayForm.vue
@@ -166,6 +166,14 @@ function downloadZip() {
     :map-presets="mapPresets"
     @update-meta="
       (newErrors: ReplayErrors, newMeta: ReplayMetadata) => {
+        if (newMeta?.maps?.pickedMaps?.length) {
+          const numOfMaps = newMeta.maps.pickedMaps.length
+          if (numOfMaps % 2 == 0) {
+            setGames(numOfMaps - 1)
+          } else {
+            setGames(numOfMaps)
+          }
+        }
         meta = newMeta
         metaErrors = newErrors
       }

--- a/src/components/SetInfo.vue
+++ b/src/components/SetInfo.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+const emit = defineEmits<{
+  setGames: [number]
+}>()
+const props = defineProps<{
+  gamesCount: number
+}>()
+</script>
+<template>
+  <div class="mt-4 text-center">
+    <ul class="grid w-full gap-6 md:grid-cols-5">
+      <li>
+        <input
+          type="radio"
+          id="bo3"
+          name="bo"
+          value="3"
+          class="hidden peer"
+          required
+          :checked="props.gamesCount == 3"
+          @change="emit('setGames', 3)"
+        />
+        <label
+          for="bo3"
+          class="inline-flex items-center justify-between w-full p-5 text-gray-500 bg-white border-2 rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 dark:peer-checked:text-blue-500 peer-checked:border-blue-600 peer-checked:text-blue-600 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700"
+        >
+          <div class="block">
+            <div class="w-full text-lg font-semibold">Best of 3</div>
+          </div>
+        </label>
+      </li>
+      <li>
+        <input
+          type="radio"
+          id="bo5"
+          name="bo"
+          value="5"
+          class="hidden peer"
+          :checked="props.gamesCount == 5"
+          @change="emit('setGames', 5)"
+        />
+        <label
+          for="bo5"
+          class="inline-flex items-center justify-between w-full p-5 text-gray-500 bg-white border-2 border-gray-200 rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 dark:peer-checked:text-blue-500 peer-checked:border-blue-600 peer-checked:text-blue-600 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700"
+        >
+          <div class="block">
+            <div class="w-full text-lg font-semibold">Best of 5</div>
+          </div>
+        </label>
+      </li>
+      <li>
+        <input
+          type="radio"
+          id="bo7"
+          name="bo"
+          value="7"
+          class="hidden peer"
+          :checked="props.gamesCount == 7"
+          @change="emit('setGames', 7)"
+        />
+        <label
+          for="bo7"
+          class="inline-flex items-center justify-between w-full p-5 text-gray-500 bg-white border border-gray-200 rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 dark:peer-checked:text-blue-500 peer-checked:border-blue-600 peer-checked:text-blue-600 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700"
+        >
+          <div class="block">
+            <div class="w-full text-lg font-semibold">Best of 7</div>
+          </div>
+        </label>
+      </li>
+      <li>
+        <input
+          type="radio"
+          id="bo9"
+          name="bo"
+          value="9"
+          class="hidden peer"
+          :checked="props.gamesCount == 9"
+          @change="emit('setGames', 9)"
+        />
+        <label
+          for="bo9"
+          class="inline-flex items-center justify-between w-full p-5 text-gray-500 bg-white border border-gray-200 rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 dark:peer-checked:text-blue-500 peer-checked:border-blue-600 peer-checked:text-blue-600 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700"
+        >
+          <div class="block">
+            <div class="w-full text-lg font-semibold">Best of 9</div>
+          </div>
+        </label>
+      </li>
+      <li>
+        <input
+          type="radio"
+          id="bo11"
+          name="bo"
+          value="11"
+          class="hidden peer"
+          :checked="props.gamesCount == 11"
+          @change="emit('setGames', 11)"
+        />
+        <label
+          for="bo11"
+          class="inline-flex items-center justify-between w-full p-5 text-gray-500 bg-white border border-gray-200 rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 dark:peer-checked:text-blue-500 peer-checked:border-blue-600 peer-checked:text-blue-600 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700"
+        >
+          <div class="block">
+            <div class="w-full text-lg font-semibold">Best of 11</div>
+          </div>
+        </label>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/src/entities/draft.ts
+++ b/src/entities/draft.ts
@@ -1,42 +1,41 @@
-
 enum DraftType {
-    Unknown,
-    Map,
-    Civ
+  Unknown,
+  Map,
+  Civ
 }
 
 export type draft = {
-    draftId: string
-    presetId: string
-    title: string
-    nameHost: string
-    nameGuest: string
+  draftId: string
+  presetId: string
+  title: string
+  nameHost: string
+  nameGuest: string
 }
 
 function getDraftType(draft: draft, mapPresets: string[], civPresets: string[]) {
-    if (mapPresets.includes(draft.presetId)) {
-        return DraftType.Map
-    } else if (civPresets.includes(draft.presetId)) {
-        return DraftType.Civ
-    } else {
-        return DraftType.Unknown
-    }
+  if (mapPresets.includes(draft.presetId)) {
+    return DraftType.Map
+  } else if (civPresets.includes(draft.presetId)) {
+    return DraftType.Civ
+  } else {
+    return DraftType.Unknown
+  }
 }
 
 export function getDraftTypeLabel(draft: draft, mapPresets: string[], civPresets: string[]) {
-    const draftType = getDraftType(draft, mapPresets, civPresets)
-    if (draftType == DraftType.Civ) {
-        return 'Civs:'
-    } else if (draftType == DraftType.Map) {
-        return 'Maps:'
-    } else {
-        return ''
-    }
+  const draftType = getDraftType(draft, mapPresets, civPresets)
+  if (draftType == DraftType.Civ) {
+    return 'Civs:'
+  } else if (draftType == DraftType.Map) {
+    return 'Maps:'
+  } else {
+    return ''
+  }
 }
 
 export const extractDraftId = (url?: string) => {
-    if (!url) {
-        return ''
-    }
-    return url.replace(/https:\/\/aoe2cm\.net\/(draft|spectate)\//, '').replace(/\/$/, '')
+  if (!url) {
+    return ''
+  }
+  return url.replace(/https:\/\/aoe2cm\.net\/(draft|spectate)\//, '').replace(/\/$/, '')
 }

--- a/src/entities/game.test.ts
+++ b/src/entities/game.test.ts
@@ -1,49 +1,71 @@
 import { expect, test } from 'vitest'
-import { normalizePlayerName, matchName, zipFilename, computeReplayFilename, computeReplayFilenamePreview, Game, Replay } from './game'
+import {
+  normalizePlayerName,
+  matchName,
+  zipFilename,
+  computeReplayFilename,
+  computeReplayFilenamePreview,
+  Game,
+  Replay
+} from './game'
 
 test('normalizePlayerName: Do not modify acceptable name', () => {
-    expect(normalizePlayerName('Player3', 'DefaultName')).toBe('Player3')
+  expect(normalizePlayerName('Player3', 'DefaultName')).toBe('Player3')
 })
 
 test('normalizePlayerName: Remove whitespace', () => {
-    expect(normalizePlayerName(' P l a y e r 3 ', 'DefaultName')).toBe('Player3')
+  expect(normalizePlayerName(' P l a y e r 3 ', 'DefaultName')).toBe('Player3')
 })
 
 test('normalizePlayerName: Remove bad characters', () => {
-    expect(normalizePlayerName('Player<>:"/\\Three ', 'DefaultName')).toBe('PlayerThree')
+  expect(normalizePlayerName('Player<>:"/\\Three ', 'DefaultName')).toBe('PlayerThree')
 })
 
 test('normalizePlayerName: Use default name if result is empty', () => {
-    expect(normalizePlayerName('<>:"/\\', 'DefaultName')).toBe('DefaultName')
+  expect(normalizePlayerName('<>:"/\\', 'DefaultName')).toBe('DefaultName')
 })
 
 test('matchName: Generate a correct match name', () => {
-    expect(matchName('Player1', 'Player2')).toBe('Player1_vs_Player2')
+  expect(matchName('Player1', 'Player2')).toBe('Player1_vs_Player2')
 })
 
 test('zipFilename: Generate a correct zip filename', () => {
-    expect(zipFilename('Player1', 'Player2')).toBe('Player1_vs_Player2.zip')
+  expect(zipFilename('Player1', 'Player2')).toBe('Player1_vs_Player2.zip')
 })
 
 test('computeReplayFilename: Create some replay file names', () => {
-    const game1 = new Game();
-    for (let i = 0; i < 30; i++) {
-        game1.replays.push(new Replay());
-    }
+  const game1 = new Game()
+  for (let i = 0; i < 30; i++) {
+    game1.replays.push(new Replay())
+  }
 
-    expect(computeReplayFilename('Playe<>r 3', ' Pl ay::er 4 ', game1, 0, 27)).toBe('Player3_vs_Player4_G1bb.aoe2record')
-    expect(computeReplayFilename('Playe<>r 3', ' Pl ay::er 4 ', game1, 1, 25)).toBe('Player3_vs_Player4_G2az.aoe2record')
-    expect(computeReplayFilename('Playe<>r 3', ' Pl ay::er 4 ', game1, 2, 28)).toBe('Player3_vs_Player4_G3bc.aoe2record')
+  expect(computeReplayFilename('Playe<>r 3', ' Pl ay::er 4 ', game1, 0, 27)).toBe(
+    'Player3_vs_Player4_G1bb.aoe2record'
+  )
+  expect(computeReplayFilename('Playe<>r 3', ' Pl ay::er 4 ', game1, 1, 25)).toBe(
+    'Player3_vs_Player4_G2az.aoe2record'
+  )
+  expect(computeReplayFilename('Playe<>r 3', ' Pl ay::er 4 ', game1, 2, 28)).toBe(
+    'Player3_vs_Player4_G3bc.aoe2record'
+  )
 })
 
 test('computeReplayFilenamePreview: Create some replay file names', () => {
-    const game1 = new Game();
-    for (let i = 0; i < 30; i++) {
-        game1.replays.push(new Replay());
-    }
-    game1.replays[27].file = new File([""], "testfile.aoe2record", { type: 'application/octet-stream' });
+  const game1 = new Game()
+  for (let i = 0; i < 30; i++) {
+    game1.replays.push(new Replay())
+  }
+  game1.replays[27].file = new File([''], 'testfile.aoe2record', {
+    type: 'application/octet-stream'
+  })
 
-    expect(computeReplayFilenamePreview('Playe<>r 3', ' Pl ay::er 4 ', game1, 0, game1.replays[27], 27)).toBe('Player3_vs_Player4_G1bb.aoe2record')
-    expect(computeReplayFilenamePreview('Playe<>r 3', ' Pl ay::er 4 ', game1, 1, game1.replays[25], 25)).toBe('Player3_vs_Player4_G2az.aoe2record (dummy file)')
-    expect(computeReplayFilenamePreview('Playe<>r 3', ' Pl ay::er 4 ', game1, 2, game1.replays[28], 28)).toBe('Player3_vs_Player4_G3bc.aoe2record (dummy file)')
+  expect(
+    computeReplayFilenamePreview('Playe<>r 3', ' Pl ay::er 4 ', game1, 0, game1.replays[27], 27)
+  ).toBe('Player3_vs_Player4_G1bb.aoe2record')
+  expect(
+    computeReplayFilenamePreview('Playe<>r 3', ' Pl ay::er 4 ', game1, 1, game1.replays[25], 25)
+  ).toBe('Player3_vs_Player4_G2az.aoe2record (dummy file)')
+  expect(
+    computeReplayFilenamePreview('Playe<>r 3', ' Pl ay::er 4 ', game1, 2, game1.replays[28], 28)
+  ).toBe('Player3_vs_Player4_G3bc.aoe2record (dummy file)')
 })

--- a/src/entities/game.ts
+++ b/src/entities/game.ts
@@ -1,4 +1,4 @@
-import unidecode from 'unidecode';
+import unidecode from 'unidecode'
 import { logn, toBase26 } from '../lib/maths'
 
 let gameCounter = 0
@@ -22,7 +22,6 @@ export class Replay {
     this.file = null
   }
 }
-
 
 export function normalizePlayerName(playerName: string, defaultName: string) {
   const asciiName = unidecode(playerName)
@@ -51,10 +50,11 @@ export function computeReplayFilename(
   player2: string,
   game: Game,
   gameIdx: number,
-  replayIdx: number,
+  replayIdx: number
 ) {
-  const numReplays = game.replays.length;
-  const replaySubNumbering = numReplays > 1 ? toBase26(replayIdx, Math.ceil(logn(numReplays, 26))) : ''
+  const numReplays = game.replays.length
+  const replaySubNumbering =
+    numReplays > 1 ? toBase26(replayIdx, Math.ceil(logn(numReplays, 26))) : ''
   return `${matchName(normalizePlayerName(player1, 'Player1'), normalizePlayerName(player2, 'Player2'))}_G${gameIdx + 1}${replaySubNumbering}.aoe2record`
 }
 
@@ -64,7 +64,7 @@ export function computeReplayFilenamePreview(
   game: Game,
   gameIdx: number,
   replay: Replay,
-  replayIdx: number,
+  replayIdx: number
 ) {
   const filename = computeReplayFilename(
     normalizePlayerName(player1, 'Player1'),

--- a/src/lib/maths.test.ts
+++ b/src/lib/maths.test.ts
@@ -2,29 +2,29 @@ import { expect, test } from 'vitest'
 import { toBase26, logn } from './maths'
 
 test('logn: Calculate logs', () => {
-    expect(logn(8, 2)).toBe(3)
-    expect(logn(100, 10)).toBe(2)
-    expect(logn(676, 26)).toBe(2)
-    expect(logn(17576, 26)).toBe(3)
+  expect(logn(8, 2)).toBe(3)
+  expect(logn(100, 10)).toBe(2)
+  expect(logn(676, 26)).toBe(2)
+  expect(logn(17576, 26)).toBe(3)
 })
 
 test('toBase26: Convert small numbers', () => {
-    expect(toBase26(0, 1)).toBe('a')
-    expect(toBase26(1, 1)).toBe('b')
-    expect(toBase26(2, 1)).toBe('c')
-    expect(toBase26(3, 1)).toBe('d')
+  expect(toBase26(0, 1)).toBe('a')
+  expect(toBase26(1, 1)).toBe('b')
+  expect(toBase26(2, 1)).toBe('c')
+  expect(toBase26(3, 1)).toBe('d')
 })
 
 test('toBase26: Convert large numbers', () => {
-    expect(toBase26(25, 2)).toBe('az')
-    expect(toBase26(26, 2)).toBe('ba')
-    expect(toBase26(27, 2)).toBe('bb')
-    expect(toBase26(28, 2)).toBe('bc')
+  expect(toBase26(25, 2)).toBe('az')
+  expect(toBase26(26, 2)).toBe('ba')
+  expect(toBase26(27, 2)).toBe('bb')
+  expect(toBase26(28, 2)).toBe('bc')
 })
 
 test('toBase26: Convert very large numbers', () => {
-    expect(toBase26(675, 3)).toBe('azz')
-    expect(toBase26(676, 3)).toBe('baa')
-    expect(toBase26(677, 3)).toBe('bab')
-    expect(toBase26(678, 3)).toBe('bac')
+  expect(toBase26(675, 3)).toBe('azz')
+  expect(toBase26(676, 3)).toBe('baa')
+  expect(toBase26(677, 3)).toBe('bab')
+  expect(toBase26(678, 3)).toBe('bac')
 })

--- a/src/lib/maths.ts
+++ b/src/lib/maths.ts
@@ -1,15 +1,14 @@
-
 export function toBase26(value: number, width: number) {
-    const res = []
-    value = Math.floor(value)
-    do {
-        const digit = value % 26
-        value = Math.floor(value / 26)
-        res.push(String.fromCharCode(0x61 + digit))
-    } while (value > 0)
-    return res.reverse().join('').padStart(width, 'a')
+  const res = []
+  value = Math.floor(value)
+  do {
+    const digit = value % 26
+    value = Math.floor(value / 26)
+    res.push(String.fromCharCode(0x61 + digit))
+  } while (value > 0)
+  return res.reverse().join('').padStart(width, 'a')
 }
 
 export function logn(x: number, y: number) {
-    return Math.log(x) / Math.log(y);
+  return Math.log(x) / Math.log(y)
 }


### PR DESCRIPTION
Add checkboxes to select the number of games in the set.
This removes the possibility of an arbitrary number of games, but I am not aware of a case where that would be useful.

Note: There are other changes in formatting only. I ran `npm run format` before commiting and those files were already not formatted correctly.

![image](https://github.com/user-attachments/assets/35431254-fdc2-419d-a230-de7c342596d0)
