### PR TITLE
Add text template for discord post

### DIFF
--- a/src/components/DiscordMessage.vue
+++ b/src/components/DiscordMessage.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const props = defineProps<{ discordMessage: string }>()
+
+const copyDone = ref(false)
+async function copyDiscordMessage() {
+  try {
+    await navigator.clipboard.writeText(props.discordMessage)
+    copyDone.value = true
+    setTimeout(() => {
+      copyDone.value = false
+    }, 2000)
+  } catch (error) {
+    console.error(error)
+  }
+}
+</script>
+<template>
+  <h2 class="text-center text-2xl">Discord Message</h2>
+  <div class="w-full max-w-lg text-left">
+    <p class="mb-4">
+      Complete your submission by upload the file in the correct discord channel and use the
+      following message as a template:
+    </p>
+    <div class="relative bg-gray-50 rounded-lg dark:bg-gray-700 p-4 h-64">
+      <div class="overflow-scroll max-h-full">
+        <pre>{{ discordMessage }}</pre>
+      </div>
+      <div class="absolute top-2 end-2 bg-gray-50 dark:bg-gray-700">
+        <button
+          @click="copyDiscordMessage"
+          class="text-gray-900 dark:text-gray-400 m-0.5 hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-600 dark:hover:bg-gray-700 rounded-lg py-2 px-2.5 inline-flex items-center justify-center bg-white border-gray-200 border"
+        >
+          <span v-if="!copyDone" id="default-message" class="inline-flex items-center">
+            <svg
+              class="w-3 h-3 me-1.5"
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 18 20"
+            >
+              <path
+                d="M16 1h-3.278A1.992 1.992 0 0 0 11 0H7a1.993 1.993 0 0 0-1.722 1H2a2 2 0 0 0-2 2v15a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2Zm-3 14H5a1 1 0 0 1 0-2h8a1 1 0 0 1 0 2Zm0-4H5a1 1 0 0 1 0-2h8a1 1 0 1 1 0 2Zm0-5H5a1 1 0 0 1 0-2h2V2h4v2h2a1 1 0 1 1 0 2Z"
+              />
+            </svg>
+            <span class="text-xs font-semibold">Copy message</span>
+          </span>
+          <span v-else id="success-message" class="inline-flex items-center">
+            <svg
+              class="w-3 h-3 text-blue-700 dark:text-blue-500 me-1.5"
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 16 12"
+            >
+              <path
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M1 5.917 5.724 10.5 15 1.5"
+              />
+            </svg>
+            <span class="text-xs font-semibold text-blue-700 dark:text-blue-500">Copied</span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/ReplayForm.vue
+++ b/src/components/ReplayForm.vue
@@ -8,6 +8,7 @@ import GameInfo from './GameInfo.vue'
 import GameBox from './GameBox.vue'
 import ZipPreviewPane from './ZipPreviewPane.vue'
 import RecentDrafts from './RecentDrafts.vue'
+import DiscordMessage from './DiscordMessage.vue'
 import type { ReplayMetadata, ReplayErrors } from '../entities/gamemeta'
 
 import { Game, Replay, zipFilename, computeReplayFilename } from '../entities/game'
@@ -131,6 +132,13 @@ function downloadZip() {
       saveAs(blob, zipFilename(player1.value, player2.value))
     })
 }
+
+const discordMessage = computed(
+  () => `${player1.value} vs ${player2.value}
+Best of ${games.value.length}
+Map draft: ${mapDraft.value}
+Civ draft: ${civDraft.value}`
+)
 </script>
 
 <template>
@@ -189,5 +197,9 @@ function downloadZip() {
     >
       Download
     </button>
+  </div>
+
+  <div class="text-center p-4 border-2 col-span-3 mt-4">
+    <DiscordMessage :discord-message="discordMessage" />
   </div>
 </template>


### PR DESCRIPTION
Add text area with a template for the discord message for the submission, with button to copy the text in the clipboard

![image](https://github.com/user-attachments/assets/8669d0f8-e8ec-4714-9029-3f5d24b29105)
