### PR TITLE
Use player profile and name to keep the score consistent

### DIFF
--- a/src/components/GameTable.vue
+++ b/src/components/GameTable.vue
@@ -2,6 +2,7 @@
 import DummyGame from '@/components/DummyGame.vue'
 import ParsedGame from '@/components/ParsedGame.vue'
 import { useGamesStore } from '@/stores/games'
+import type { GameWinner } from '@/entities/game'
 
 const gamesStore = useGamesStore()
 
@@ -24,7 +25,7 @@ const { showResults = true } = defineProps<{
       :index="index"
       :num-games="gamesStore.realGamesCount"
       :show-results="showResults"
-      @set-winner="(winner: 'left' | 'none' | 'right') => (game.winner = winner)"
+      @set-winner="(winner: GameWinner) => (game.winner = winner)"
       @move="(direction: 'up' | 'down') => gamesStore.moveGame(index, direction == 'up' ? -1 : 1)"
     >
     </component>


### PR DESCRIPTION
Use the player profile IDs to attribute the score to the same player, regardless of who is host and who is guest in each game. Also try to match the player's side with the name from the draft.

Addresses most concerns of #48