### PR TITLE
Correctly detect custom civ presets

### DIFF
--- a/src/components/GameInfo.vue
+++ b/src/components/GameInfo.vue
@@ -7,6 +7,7 @@ import { MatchSetType } from '@/entities/matchset'
 import debounce from 'lodash.debounce'
 import CivIcon from './CivIcon.vue'
 import { extractDraftId } from '../entities/draft'
+import { civNames } from '@/entities/civs'
 
 const props = defineProps<{
   expectedGamesCount: number
@@ -126,7 +127,11 @@ const debouncedFetchCivs = debounce(async () => {
   }
 
   const json = await response.json()
-  if (!('encodedCivilisations' in json.preset)) {
+  const civNamesSet = new Set(Object.values(civNames))
+  if (
+    !('encodedCivilisations' in json.preset) &&
+    json.preset.draftOptions.every(({ id }: { id: string }) => !civNamesSet.has(id))
+  ) {
     errors.value.civs = 'This does not seem to be a civ draft'
     emit('updateMeta', errors.value, meta.value)
     return


### PR DESCRIPTION
Custom civ presets were not detected as civ drafts because they do not include an `encodedCivilizations` key, but rather have normal `draftOptions`. This change checks if the list of draft options contains a known civilization to determine whether it is a map or a civ draft.